### PR TITLE
Supported the root directory.

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -38,6 +38,7 @@ function switchLang(lang){
 }
 
 function i18n_url(path, language) {
+  var root = this.config.root || '';
   var lang = language ? language : this.page.lang;
   var url = this.url_for(path);
 
@@ -56,7 +57,7 @@ function i18n_url(path, language) {
   }
   
   if (lang && lang !== languages[0]){
-    url = '/' + lang + url;
+    url = root + lang + url.replace(root, '/');
   }
 
   return url;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-generator-i18n",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Multi-language pages generator for Hexo.",
   "main": "index",
   "directories": {


### PR DESCRIPTION
If a website is in a subdirectory (such as http://example.org/blog) , `url_for_lang` should look like this : `/subdirectory/lang/path`