### PR TITLE
Move index generator to the end of array

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@ language: [zh,en]
 # config hexo-generator-i18n option (optional, this is default option)
 i18n:
   type: [page, post]
-  generator: [index, archive, category, tag]
+  generator: [archive, category, tag, index]
 ```
 
 - **type**: What type of model to be i18n generated
  - page: All page model under <var>source</var>
  - post: All post model under <var>source</var>/<var>_post</var>
 - **generator**: Which generator to be i18n generated, it's array of your installed generator names.
- - index: Generate i18n index page
  - archive: Generate i18n archive page
  - category: Generate i18n category page
  - tag: Generate i18n tag page
+ - index: Generate i18n index page
 
 ***And add xx.yml (such as zh.yml, en.yml) under your themes languages directory***
  

--- a/README_zh.md
+++ b/README_zh.md
@@ -23,17 +23,17 @@ language: [zh,en]
 # hexo-generator-i18n 选项（可选，默认使用如下设置）
 i18n:
   type: [page, post]
-  generator: [index, archive, category, tag]
+  generator: [archive, category, tag, index]
 ```
 
 - **type**: 想要生成国际化页面类型
  - page: <var>source</var>目录下的所有page页面
  - post: <var>source</var>/<var>_post</var>目录下所有的post页面
 - **generator**: 设置需要国际化的其它生成器。
- - index: 生成国际化首页
  - archive: 生成国际化归档页
  - category: 生成国际化分类页
  - tag: 生成国际化标签页
+ - index: 生成国际化首页
 
 ***在主题languages目录下添加对应的语言.yml文件(如zh.yml, en.yml)***
  

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var _ = require('lodash');
     hexo.log.info('i18n not config in _config.yml, use default config!\nPlease visit https://github.com/Jamling/hexo-generator-i18n for more information');
     hexo.config.i18n = {
       type: ["page", "post"],
-      generator: ["index", "archive", "category", "tag"]
+      generator: ["archive", "category", "tag", "index"]
     }
   }
   if (!hexo.config.i18n.languages){


### PR DESCRIPTION
When "index" generator is set as the first one, there is a problem
with generating index page for other than default language.
Suggesting this order in official documentation may lead to
frustration, because solution is not so obvious and most of the
new users follow the instruction by copy/paste method.
This lead to situation where generator not working as it should.

Let's inform about "valid" order from the beginning.